### PR TITLE
岩とピンが衝突するように修正

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,9 @@ import { create, preload, update } from "./picture-group";
 const D_WIDTH = 1000;
 const D_HEIGHT = 600;
 // 1, Phaser3の設定データ
+/**
+ * @type {Phaser.Types.Core.GameConfig}
+ */
 export const config = {
   type: Phaser.AUTO,
   width: D_WIDTH, // ゲーム画面の横幅
@@ -23,7 +26,7 @@ export const config = {
   physics: {
     default: "arcade",
     arcade: {
-      debug: false, // スプライトに緑の枠を表示しない
+      debug: true, // スプライトに緑の枠を表示しない
       gravity: { y: 300 }, // 重力の方向とその強さ
     },
   },

--- a/js/picture-group.js
+++ b/js/picture-group.js
@@ -37,7 +37,7 @@ export function create() {
   treasure.setDisplaySize(150, 150);
 
   walls = this.physics.add.staticGroup();
-  
+
   for (var j = 3; j < 10; j++) {
     walls.create(850, j * 60, 'wallX').setScale(0.04);// 壁右
     walls.create(150, j * 60, 'wallX').setScale(0.04);// 壁左
@@ -51,24 +51,55 @@ export function create() {
     walls.create(i * 100 + 490, 321, "wallY").setScale(0.04);//足場右
   }
 
-  // グループの作成
-  pins = this.physics.add.staticGroup();
+  // 動的グループの作成
+  pins = this.physics.add.group();
+
+  const halfRotationDegree = Math.PI + 0.04;
 
   // ピンの追加
-  const pin1 = pins.create(640, 465, "pin"); //右のピン
+  /**
+   * @type {Phaser.Physics.Arcade.Image}
+   */
+  const pin1 = pins.create(640, 465, "pin");
   pin1.setDisplaySize(50, 300);
-  pin1.setRotation(Math.PI + 0.04); // ラジアン単位で回転角度を指定
-  pin1.setInteractive(); // 画像をクリック可能にする
+  // 他の物体と衝突しても動かないようにした
+  pin1.setImmovable(true);
+  pin1.setInteractive();
+  pin1.setRotation(halfRotationDegree);
+  /*
+  ? 重力加速度と速さをリセットしてもなぜか効果がなく
+  ? 重力の干渉を受けないようにするために setAllowGravity を false にするしかなかった
+   */
+  // pin1.setGravityY(0);
+  // pin1.setVelocity(0);
+  pin1.body.setAllowGravity(false);
 
+  /**
+   * @type {Phaser.Physics.Arcade.Image}
+   */
   const pin2 = pins.create(360, 465, "pin"); //左のピン
   pin2.setDisplaySize(50, 300);
-  pin2.setRotation(Math.PI + 0.04);
   pin2.setInteractive(); // 画像をクリック可能にする
+  pin2.setImmovable(true);
+  pin2.body.setAllowGravity(false);
+  pin2.setRotation(halfRotationDegree);
 
+  /**
+   * @type {Phaser.Physics.Arcade.Image}
+   */
   const pin3 = pins.create(500, 310, "pin");
-  pin3.setDisplaySize(50, 300);
-  pin3.setRotation(Math.PI / 2 + 0.04);
-  pin3.setInteractive(); // 画像をクリック可能にする
+  /*
+    pin3 を擬似的に 90 度回転
+    setRotation は bouding box の位置は不変なため、setSize によって bounding box の位置調整をする必要あり
+   */
+  pin3.setSize(pin3.height, pin3.width);
+  pin3.setRotation((1 / 2) * halfRotationDegree);
+
+  pin3.setDisplaySize(50, 310);
+  // 画像をクリック可能にする
+  pin3.setInteractive();
+  pin3.setImmovable(true);
+  pin3.body.setAllowGravity(false);
 
   rocks = this.physics.add.image(500, 200, "rock");
   rocks.setDisplaySize(150, 150);


### PR DESCRIPTION
# Problem
岩とピンが衝突していなかった（というよりも最初からずっと衝突していた）
`setRectangle` は見た目は回転するものの、bouding box（衝突境界線）は回転しません
この bouding box をいじっていなかったため、運悪くピンと岩は最初からずっと衝突しており、あたかも衝突していないような挙動を示していました


# solution
ピンを動的オブジェクトにして、bouding box を調整した

# result
https://github.com/gafu2317/game/assets/90585006/19dfb844-3e5c-4aab-a497-7c733349dda0


基本的に動くものは動的オブジェクトにしたほうが良いんじゃないかな、と僕は思いました
（公式ドキュメント読んでないから本当はどっちが良いかわからない）
壁は動かないので静的オブジェクトかな、と

あくまで参考程度に！